### PR TITLE
Set unity message handler to nil on app terminate and reseting on unity init

### DIFF
--- a/ios/Classes/UnityPlayerUtils.swift
+++ b/ios/Classes/UnityPlayerUtils.swift
@@ -84,9 +84,9 @@ var sharedApplication: UIApplication?
             if (self.ufw?.appController().unityMessageHandler == nil) {
                 self.ufw?.appController().unityMessageHandler = self.unityMessageHandlers
             }
-            if (self.ufw?.appController().unitySceneLoadedHandler == nil) {
-                self.ufw?.appController().unitySceneLoadedHandler = self.unitySceneLoadedHandlers
-            }
+            // if (self.ufw?.appController().unitySceneLoadedHandler == nil) {
+            //     self.ufw?.appController().unitySceneLoadedHandler = self.unitySceneLoadedHandlers
+            // }
             self.ufw?.showUnityWindow()
             return
         }
@@ -191,7 +191,7 @@ var sharedApplication: UIApplication?
             unityAppController?.applicationDidBecomeActive(application)
         } else if notification?.name == UIApplication.willTerminateNotification {
             unityAppController?.unityMessageHandler = nil
-            unityAppController?.unitySceneLoadedHandler = nil
+            // unityAppController?.unitySceneLoadedHandler = nil
             unityAppController?.applicationWillTerminate(application)
         } else if notification?.name == UIApplication.didReceiveMemoryWarningNotification {
             unityAppController?.applicationDidReceiveMemoryWarning(application)

--- a/ios/Classes/UnityPlayerUtils.swift
+++ b/ios/Classes/UnityPlayerUtils.swift
@@ -190,8 +190,8 @@ var sharedApplication: UIApplication?
         } else if notification?.name == UIApplication.didBecomeActiveNotification {
             unityAppController?.applicationDidBecomeActive(application)
         } else if notification?.name == UIApplication.willTerminateNotification {
-            if (isUnityAppReady()) {
-                GetUnityPlayerUtils().ufw?.pause(true)
+            if (_isUnityReady) {
+                self.ufw?.pause(true)
             }
             unityAppController?.unityMessageHandler = nil
             // unityAppController?.unitySceneLoadedHandler = nil

--- a/ios/Classes/UnityPlayerUtils.swift
+++ b/ios/Classes/UnityPlayerUtils.swift
@@ -190,6 +190,9 @@ var sharedApplication: UIApplication?
         } else if notification?.name == UIApplication.didBecomeActiveNotification {
             unityAppController?.applicationDidBecomeActive(application)
         } else if notification?.name == UIApplication.willTerminateNotification {
+            if (isUnityAppReady()) {
+                GetUnityPlayerUtils().ufw?.pause(true)
+            }
             unityAppController?.unityMessageHandler = nil
             // unityAppController?.unitySceneLoadedHandler = nil
             unityAppController?.applicationWillTerminate(application)

--- a/ios/Classes/UnityPlayerUtils.swift
+++ b/ios/Classes/UnityPlayerUtils.swift
@@ -84,9 +84,6 @@ var sharedApplication: UIApplication?
             if (self.ufw?.appController().unityMessageHandler == nil) {
                 self.ufw?.appController().unityMessageHandler = self.unityMessageHandlers
             }
-            // if (self.ufw?.appController().unitySceneLoadedHandler == nil) {
-            //     self.ufw?.appController().unitySceneLoadedHandler = self.unitySceneLoadedHandlers
-            // }
             self.ufw?.showUnityWindow()
             return
         }
@@ -194,7 +191,6 @@ var sharedApplication: UIApplication?
                 self.ufw?.pause(true)
             }
             unityAppController?.unityMessageHandler = nil
-            // unityAppController?.unitySceneLoadedHandler = nil
             unityAppController?.applicationWillTerminate(application)
         } else if notification?.name == UIApplication.didReceiveMemoryWarningNotification {
             unityAppController?.applicationDidReceiveMemoryWarning(application)

--- a/ios/Classes/UnityPlayerUtils.swift
+++ b/ios/Classes/UnityPlayerUtils.swift
@@ -187,9 +187,20 @@ var sharedApplication: UIApplication?
         } else if notification?.name == UIApplication.didBecomeActiveNotification {
             unityAppController?.applicationDidBecomeActive(application)
         } else if notification?.name == UIApplication.willTerminateNotification {
+            // pause the unity player before app is terminated
+            // this is to replicate the behavior of unity player when app is terminated
+            // to as was there in 4.2.81 and previous versions
+            // this will pause the unity and it's events
+            // which is right now causing crash in flutter side
+            // Exception: "Cannot create web request without initializing the system"
             if (_isUnityReady) {
                 self.ufw?.pause(true)
             }
+            // setting unityMessageHandler to nil to avoid sending messages to flutter
+            // as right now after 4.2.82 release for background foreground pause resume
+            // when app is terminated unity is sending message for AppState/GameEnd to flutter
+            // which is causing crash in flutter side 
+            // Exception: "Sending message before FlutterEngine is run."
             unityAppController?.unityMessageHandler = nil
             unityAppController?.applicationWillTerminate(application)
         } else if notification?.name == UIApplication.didReceiveMemoryWarningNotification {

--- a/ios/Classes/UnityPlayerUtils.swift
+++ b/ios/Classes/UnityPlayerUtils.swift
@@ -81,6 +81,12 @@ var sharedApplication: UIApplication?
 
     func initUnity() {
         if (self.unityIsInitiallized()) {
+            if (self.ufw?.appController().unityMessageHandler == nil) {
+                self.ufw?.appController().unityMessageHandler = self.unityMessageHandlers
+            }
+            if (self.ufw?.appController().unitySceneLoadedHandler == nil) {
+                self.ufw?.appController().unitySceneLoadedHandler = self.unitySceneLoadedHandlers
+            }
             self.ufw?.showUnityWindow()
             return
         }
@@ -184,6 +190,8 @@ var sharedApplication: UIApplication?
         } else if notification?.name == UIApplication.didBecomeActiveNotification {
             unityAppController?.applicationDidBecomeActive(application)
         } else if notification?.name == UIApplication.willTerminateNotification {
+            unityAppController?.unityMessageHandler = nil
+            unityAppController?.unitySceneLoadedHandler = nil
             unityAppController?.applicationWillTerminate(application)
         } else if notification?.name == UIApplication.didReceiveMemoryWarningNotification {
             unityAppController?.applicationDidReceiveMemoryWarning(application)


### PR DESCRIPTION
## Description

Set unity message handler to nil on app terminate and reseting on unity init, so that we can avoid Unity sending message when the app is terminated and the flutter message channel is not found. 

FlutterEngine.mm #1253

In order solve crashes like 

`default	14:03:36.242197+0530	Runner	*** Assertion failure in -[FlutterEngine sendOnChannel:message:binaryReply:], FlutterEngine.mm:1253
default	14:03:36.570760+0530	Runner	*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Sending a message before the FlutterEngine has been run.'
default	14:05:45.137068+0530	Runner	*** Assertion failure in -[FlutterEngine sendOnChannel:message:binaryReply:], FlutterEngine.mm:1253
default	14:05:45.488660+0530	Runner	*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Sending a message before the FlutterEngine has been run.'
`


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
